### PR TITLE
updated table schemas

### DIFF
--- a/schemas/ga4_data_streams_schema.json
+++ b/schemas/ga4_data_streams_schema.json
@@ -42,17 +42,17 @@
     "type": "RECORD",
     "fields": [{
       "mode": "NULLABLE",
-      "name": "default_uri",
-      "type": "STRING"
-    },
-    {
-      "mode": "NULLABLE",
       "name": "measurement_id",
       "type": "STRING"
     },
     {
       "mode": "NULLABLE",
       "name": "firebase_app_id",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "default_uri",
       "type": "STRING"
     }]
   },
@@ -87,6 +87,3 @@
     }]
   }
 ]
-
-
-

--- a/schemas/ga4_google_ads_links_schema.json
+++ b/schemas/ga4_google_ads_links_schema.json
@@ -2,7 +2,7 @@
   {
     "mode": "NULLABLE",
     "name": "update_time",
-    "type": "DATETIME"
+    "type": "TIMESTAMP"
   },
   {
     "mode": "NULLABLE",
@@ -42,6 +42,6 @@
   {
     "mode": "NULLABLE",
     "name": "create_time",
-    "type": "DATETIME"
+    "type": "TIMESTAMP"
   }
 ]


### PR DESCRIPTION
# Summary
Two of the BigQuery table schemas used in the deployment script have changed:
- ga4_data_streams_schema
  - order of fields in record `web_stream_data`
- ga4_google_ads_links_schema
  - fields `update_time` and `create_time` now use `TIMESTAMP` instead of `DATETIME`

